### PR TITLE
docs: note archived status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!WARNING]
+> This repo is archived. It won't receive new features, bug fixes, or security updates.
+>
+> Published releases (up to `v0.0.6`) stay available on the [GitHub Marketplace](https://github.com/marketplace/actions/supabase-embeddings-generator). Pin to the version you're already on and it'll keep working.
+
+---
+
 # Supabase Embeddings Generator
 
 A GitHub Action that converts your markdown files into embeddings and stores them in your Postgres/Supabase database, allowing you to perform vector similarity search inside your documentation and website.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > This repo is archived. It won't receive new features, bug fixes, or security updates.
 >
-> Published releases (up to `v0.0.6`) stay available on the [GitHub Marketplace](https://github.com/marketplace/actions/supabase-embeddings-generator). Pin to the version you're already on and it'll keep working.
+> Published releases (up to `v0.0.6`) stay available on the [GitHub Marketplace](https://github.com/marketplace/actions/supabase-embeddings-generator) and will keep working.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This action is a companion to the [`headless-vector-search`](https://github.com/
 
 ## Usage
 
-You can find this action on the [GitHub Marketplace](https://github.com/marketplace/actions/supabase-embeddings-generator).
-
 In your knowledge base repository, create a new action called `.github/workflows/generate_embeddings.yml` with the following content:
 
 ```yml
@@ -29,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: supabase/embeddings-generator@v0.x.x # Find the latest version in the Marketplace
+      - uses: supabase/embeddings-generator@v0.x.x # Find the latest version in the repo's releases
         with:
           supabase-url: 'https://your-project-ref.supabase.co'
           supabase-service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > This repo is archived. It won't receive new features, bug fixes, or security updates.
 >
-> Published releases (up to `v0.0.6`) stay available on the [GitHub Marketplace](https://github.com/marketplace/actions/supabase-embeddings-generator) and will keep working.
+> Published releases (up to `v0.0.6`) stay available and will keep working in existing workflows.
 
 ---
 


### PR DESCRIPTION
Adds an archive notice to the README ahead of archiving the repo.

See formatted preview: https://github.com/supabase/embeddings-generator/blob/mattrossman/ai-948-archive-embeddings-generator-repo/README.md

Open question:
- Do we delist from marketplace? IIUC this doesn't impact consumption of the workflow with `uses:`, it's more of a discoverability thing. I think we should delist and remove mentions of the marketplace from README alongside this banner.

Ref AI-948
